### PR TITLE
fix: hover link color from grey to white

### DIFF
--- a/src/scss/_component.section.scss
+++ b/src/scss/_component.section.scss
@@ -52,7 +52,7 @@
     }
 
     &:hover {
-      color: $c-grey;
+      color: $c-white;
     }
 
     &:hover::after {


### PR DESCRIPTION
### Description
Change section link hover color to white.

### Issue

__#5__, opens issue __#12__

### To Validate

1. Pull down branch `fix--link-hover-color`
2. Run `npm i`
3. Run `npm start`
4. Navigate to `localhost:3000/git`
5. Scroll to the bottom where the project prompts are
6. Hover over one of the underlined links