### PR TITLE
📝 docs(Readme): Resolve codeblock errors and correct spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,36 +32,38 @@ This guide includes the following topics: Git & GitHub, Dotfiles, HTML & CSS, Ja
             - All of the handlebars files are located in the `templates` folder. Handlebars is a templating language that makes it easier to maintain static sites, especially when there are instances of repetitive markup, such as a header or footer that is used on every page.
                 - `layouts` contains a file that sets the layout for all of the pages.
                 - `pages` is where all of the pages live before they are compiled into `html` files. Each page must contain the following code at the beginning of the file:
-                    ```---
+                 ```
+                    ---
                     layoutFile: default
                     dataFile: common/*
-                    ---```
-                    
-                    - The `layoutFile` references the file in the `layout` folder, which sets the html, head, and body tag.
-                    - The `dataFile` references the directory that data will be pulled into the file when it's compiled. 
+                    ---
+                ```
+
+                - The `layoutFile` references the file in the `layout` folder, which sets the html, head, and body tag.
+                - The `dataFile` references the directory that data will be pulled into the file when it's compiled.
           
           		- `partials` is where the different pieces of the page live. These partials can be reused across the site with different data being introduced for each instance.
                   - `blog` contains all of the blog posts for the TIL page. These handlebar files will use the markdown helper so posts can be written using markdown
 
 ### Hosting
-This project is hosted through GitHub pages from the `gh-pages` branch. Once a PR is approved, it will be merged into master. Then those changes will be deployed to the `gh-pages` branch. 
+This project is hosted through GitHub pages from the `gh-pages` branch. Once a PR is approved, it will be merged into master. Then those changes will be deployed to the `gh-pages` branch.
 
 ### Contribute
 
 **Open Source Contibutors**
 
 1. Fork the repository
-2. Clone the forked repository in your ternminal
+2. Clone the forked repository in your terminal
 	- `git clone *url-of-repo*`
-3. In your local environment create a branch off of master
+3. In your local environment create a branch off of `master`
 	- `git checkout -b *name--of-branch*`
 2. Make changes and push them up with a commit following [this style](https://github.com/sparkbox/standard/tree/master/code-style/git#the-art-of-the-commit-message).
-	- `git commit -m 'type of changes: descripe changes`
+	- `git commit -m 'type of changes: describe changes`
 	- i.e `git commit -m 'fix: adds a11y attribute to links'`
-3. Navigate to this repository. 
+3. Navigate to this repository.
 4. Open a PR with your branch compared to this repo's master branch
 5. Let a collaborator take your PR and review it
-6. Keep an eye out for any feedback or comments 
+6. Keep an eye out for any feedback or comments
 7. Once approved and no more changes are needed
    - [Sync your forked repo](https://gist.github.com/corinneling/c027da69442ea08c5e67e71f72afe3c8) with this repo's master branch
    - Have your reviewer merge your branch into master with fast forward only 
@@ -75,4 +77,4 @@ If you find an issue you would like to tackle, add a comment to the issue saying
 
 You will likely get feedback on your PR, related to how you can change or improve it. Make sure to check back on your PR when you get a chance to see if your reviewer has tagged your github handle in a comment and left you some feedback.
 
-_PRs must be approved by a reviewer to be merged_
+_PRs must be approved by a reviewer to be merged._


### PR DESCRIPTION
### Description
- Fix a code block formatting problem in the readme
- Resolve spelling errors in a couple places
- Remove whitespace where VSCode told me it wasn't needed. 

### Issue
Closes #6

### Validate

Add steps on how your PR reviewer can validate that your changes are present and work

1. Pull down branch `name-of-branch`
2. Check through the Readme for resolved formatting