### PR TITLE
:memo: docs: fix typos and add a link to Flywheel

### DIFF
--- a/data/common/wordpress.yml
+++ b/data/common/wordpress.yml
@@ -1,11 +1,11 @@
 topic:
 section:
   - subtitle: CMS
-    copy: WordPress is a Content Managment System, or CMS, that allows you to build and manage your website with just your browser.
+    copy: WordPress is a Content Management System, or CMS, that allows you to build and manage your website with just your browser.
   - subtitle: Plugins
     copy: Stay away from plugins when you can because they slow down your website. Most likely your theme comes with the functionality you are looking for.
   - subtitle: Speed
-    copy: Speed tests are helpful when doing a speed audit. This can be for a website you have created, or one you are taking over. If you want to speed up a website after an audit, give an estimated sprice to your client.
+    copy: Speed tests are helpful when doing a speed audit. This can be for a website you have created, or one you are taking over. If you want to speed up a website after an audit, give an estimated price to your client.
 project:
   - subtitle: Create a WordPress Site
-    copy: Use Flywheel to create a WordPress site with a focus on something you're interested in, whether that's a cause, a cute animal, or a random topic. It can be a one page site, or have multiple pages.
+    copy: Use <a class="section__link" href="https://getflywheel.com/" target="_blank">Flywheel</a> to create a WordPress site with a focus on something you're interested in, whether that's a cause, a cute animal, or a random topic. It can be a one page site, or have multiple pages.


### PR DESCRIPTION
### Description
I updated two typos in the WordPress section and added a link to Flywheel.
### Issue
N/A
### Validate
1. Pull down branch `anastasialanz:master`
2. Run `npm i`
3. Run `npm start`
4. Navigate to `http://localhost:8000/wordpress`
5. See the corrected typos and link to Flywheel